### PR TITLE
Return early if selection type is not Range 

### DIFF
--- a/user-select-contain.js
+++ b/user-select-contain.js
@@ -21,7 +21,7 @@
     if (!currentTarget) return;
 
     const selection = window.getSelection();
-    if (!selection.rangeCount) return;
+    if (!selection.rangeCount || selection.type !== 'Range') return;
 
     const container = selection.getRangeAt(0).commonAncestorContainer;
     if (currentTarget.contains(container)) return;

--- a/user-select-contain.mjs
+++ b/user-select-contain.mjs
@@ -15,7 +15,7 @@ function handleUserSelectContain(event) {
   if (!currentTarget) return;
 
   const selection = window.getSelection();
-  if (!selection.rangeCount) return;
+  if (!selection.rangeCount || selection.type !== 'Range') return;
 
   const container = selection.getRangeAt(0).commonAncestorContainer;
   if (currentTarget.contains(container)) return;


### PR DESCRIPTION
This prevents clicks outside of the target area from leaving a `Selection` with a type of `Caret`, which was leading to text being highlighted after clicking on elements within the target range.